### PR TITLE
Patch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: node_js
+node_js:
+  - "0.10"
+  - "0.12"
+  - "4.2"
+install:
+  - npm install
+before_install:
+  - npm install -g grunt-cli
+script:
+  - grunt mochaTest
+sudo: false

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -2,6 +2,7 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-contrib-coffee');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-mocha-test');
+  grunt.loadNpmTasks('grunt-git-authors');
 
   grunt.initConfig({
     coffee: {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "url": "https://github.com/wardcunningham/wiki-plugin-transport/issues"
   },
   "engines": {
-    "node": "0.10"
+    "node": ">=0.10"
   }
 }


### PR DESCRIPTION
It is only the `package.json` change that really matters, to remove the warning seen when using later LTS versions of Node. But, nice to add testing using Travis.ci as it automates the testing.

Create an authors file by running `grunt update-authors`
