### PR TITLE
Transport Graphs

### DIFF
--- a/client/transport.coffee
+++ b/client/transport.coffee
@@ -11,12 +11,29 @@ beam = (url) ->
     resultPage = wiki.newPage(page)
     wiki.showResult resultPage
 
+graphData = ($item) ->
+  graphs = []
+  candidates = $(".item:lt(#{$('.item').index($item)})")
+  for $each in candidates
+    $each = $($each)
+    if $each.hasClass 'graph-source'
+       graphs.push $each.get(0).graphData()
+  graphs
+
+report = (object) ->
+  """<pre style="text-align: left; background-color:#fff; padding:8px;"">#{JSON.stringify object, null, '  '}</pre>"""
+
+
 emit = ($item, item) ->
   $item.append """
     <div style="background-color:#eee;padding:15px;text-align:center;">
+      <div class=preview>
+        #{report graphData($item)}
+      </div>
       <p>
         transporting through<br>
-        #{expand item.text}
+        #{expand item.text}<br>
+        <button>Beam Up</button>
       </p>
       <p class=caption>
         unavailable
@@ -29,20 +46,22 @@ emit = ($item, item) ->
 
 bind = ($item, item) ->
   $item.dblclick -> wiki.textEditor $item, item
+
   $item.find('button').click ->
-    beam item.text
+    post graphData($item)
 
   $item.on 'drop', (e) ->
     e.preventDefault()
     e.stopPropagation()
-    $page = $(e.target).parents('.page') unless e.shiftKey
-    params =
+    post
       text: e.originalEvent.dataTransfer.getData("text")
       html: e.originalEvent.dataTransfer.getData("text/html")
       url:  e.originalEvent.dataTransfer.getData("URL")
 
+  post = (params) ->
     console.log 'params',params
     $item.find('.caption').text 'waiting'
+    $page = $item.parents('.page')
 
     req =
       type: "POST",

--- a/client/transport.coffee
+++ b/client/transport.coffee
@@ -14,37 +14,44 @@ beam = (url) ->
 graphData = ($item) ->
   graphs = []
   candidates = $(".item:lt(#{$('.item').index($item)})")
-  for $each in candidates
-    $each = $($each)
-    if $each.hasClass 'graph-source'
-       graphs.push $each.get(0).graphData()
+  for each in candidates
+    if $(each).hasClass 'graph-source'
+      graphs.push each.graphData()
   graphs
 
 report = (object) ->
   """<pre style="text-align: left; background-color:#fff; padding:8px;"">#{JSON.stringify object, null, '  '}</pre>"""
 
+options = (text) ->
+  domain = m[1] if m = text.match /(https?:\/\/.*?\/)/
+  post = m[1] if m = text.match /\bPOST\b\s*(.*)/
+  graph = !!text.match /\bGRAPH\b/
+  {domain, post, graph}
 
 emit = ($item, item) ->
+  opt = options item.text
   $item.append """
     <div style="background-color:#eee;padding:15px;text-align:center;">
       <div class=preview>
-        #{report graphData($item)}
       </div>
-      <p>
+      <p class=transport-action>
         transporting through<br>
-        #{expand item.text}<br>
-        <button>Beam Up</button>
+        #{expand item.text}
       </p>
       <p class=caption>
         unavailable
       </b>
     </div>
   """
-  if match = item.text.match /(https?:\/\/.*?\/)/
-    $.get match[1], ->
+  if opt.domain
+    $.get opt.domain, ->
       $item.find('.caption').text 'ready'
+  if opt.graph
+    $item.find('.preview').html report graphData($item)
+    $item.find('.transport-action').append "<p><button>Beam Up</button></p>"
 
 bind = ($item, item) ->
+  opt = options item.text
   $item.dblclick -> wiki.textEditor $item, item
 
   $item.find('button').click ->
@@ -65,7 +72,7 @@ bind = ($item, item) ->
 
     req =
       type: "POST",
-      url: item.text.replace(/^POST\s*/,'')
+      url: opt.post
       dataType: 'json',
       contentType: "application/json",
       data: JSON.stringify(params)

--- a/client/transport.coffee
+++ b/client/transport.coffee
@@ -19,8 +19,19 @@ graphData = ($item) ->
       graphs.push each.graphData()
   graphs
 
+graphStats = ($item) ->
+  graphs = nodes = arcs = 0
+  candidates = $(".item:lt(#{$('.item').index($item)})")
+  for each in candidates
+    if $(each).hasClass 'graph-source'
+      graphs += 1
+      for node, arc of each.graphData()
+        nodes += 1
+        arcs += arc.length
+  {graphs, nodes, arcs}
+
 report = (object) ->
-  """<pre style="text-align: left; background-color:#fff; padding:8px;"">#{JSON.stringify object, null, '  '}</pre>"""
+  """<pre style="text-align: left; background-color:#ddd; padding:8px;"">#{JSON.stringify object, null, '  '}</pre>"""
 
 options = (text) ->
   domain = m[1] if m = text.match /(https?:\/\/.*?\/)/
@@ -47,7 +58,7 @@ emit = ($item, item) ->
     $.get opt.domain, ->
       $item.find('.caption').text 'ready'
   if opt.graph
-    $item.find('.preview').html report graphData($item)
+    $item.find('.preview').html report graphStats($item)
     $item.find('.transport-action').append "<p><button>Beam Up</button></p>"
 
 bind = ($item, item) ->


### PR DESCRIPTION
This experimental version supports transporting graph-source from the equally experimental Graph plugin under development with @opn. [github](https://github.com/WardCunningham/wiki-plugin-graph),  [comment](https://github.com/fedwiki/wiki/issues/63#issuecomment-213906735).

A GRAPH option in the markup offers to send parsed graph data rather than waiting for a drop.

![image](https://cloud.githubusercontent.com/assets/12127/14788484/e79b4d9e-0abc-11e6-8db1-4abdb36cc276.png)

This pull request is safe to merge but unfinished. Expect improvements soon.
