### PR TITLE
sample transporter's new address

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-plugin-transport",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Federated Wiki - Transport Plugin",
   "keywords": [
     "transport",

--- a/pages/about-transport-plugin
+++ b/pages/about-transport-plugin
@@ -19,7 +19,7 @@
     {
       "type": "transport",
       "id": "41539361b8005c94",
-      "text": "POST http://fed.wiki.org:4010/image."
+      "text": "POST http://home.c2.com:4010/image"
     },
     {
       "type": "paragraph",
@@ -261,7 +261,7 @@
       "item": {
         "type": "transport",
         "id": "41539361b8005c94",
-        "text": "POST http://fed.wiki.org:4010/image."
+        "text": "POST http://home.c2.com:4010/image"
       },
       "date": 1460865236380
     }


### PR DESCRIPTION
Having moved fed.wiki.org to a Digital Ocean server, this example service on port 4010 must be resolved with an alternate domain name. This is a change in the about page only.

![image](https://user-images.githubusercontent.com/12127/31586427-af9c74b0-b185-11e7-8bd7-2ee83c7c3500.png)
